### PR TITLE
Open Recruitment page

### DIFF
--- a/src/app/Recruitment/page.tsx
+++ b/src/app/Recruitment/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 import { VStack, Text } from "@chakra-ui/react";
 
+import { Footer } from "@/utils/components";
 import Hero from "@/utils/components/Hero";
 import BreakText from "@/utils/components/TextUtils/BreakText";
 import { RECRUITMENT_OPEN } from "@/utils/constants/Settings";
+
 
 export default function RecruitmentPage() {
  return (
@@ -32,11 +34,29 @@ export default function RecruitmentPage() {
        textAlign="center"
       >
        Applications are currently closed and will reopen in the Fall.{" "}
-       <BreakText /> Follow us on social media to stay up to date!
+       <BreakText /> Follow us on{" "}
+       <a
+        href="https://www.instagram.com/ctc.uci/"
+        target="_blank"
+        rel="noopener noreferrer"
+       >
+        <Text
+         as="span"
+         color="ctc.purple"
+         textDecoration="underline"
+         fontWeight="bold"
+         _hover={{ color: "purple.500" }}
+         transition="color 0.3s ease-out"
+        >
+         social media
+        </Text>
+       </a>{" "}
+       to stay up to date!
       </Text>
      )}
     </VStack>
    </Hero>
+   <Footer />
   </VStack>
  );
 }

--- a/src/utils/components/Navbars/DesktopNavbar.tsx
+++ b/src/utils/components/Navbars/DesktopNavbar.tsx
@@ -1,10 +1,52 @@
-import { Box, HStack, Image, Link as ChakraLink } from "@chakra-ui/react";
+import { Box, HStack, Image, Link as ChakraLink, Tooltip } from "@chakra-ui/react";
 import Link from "next/link";
 
 type DesktopNavbarProps = {
  pathname: string;
  navItems: { label: string; href: string }[];
 };
+
+function RecruitmentTooltip({ linkContent, href }: { linkContent: React.ReactNode, href: string }) {
+ return (
+  <Tooltip 
+   key={href} 
+   label={
+    <Box textAlign="center" whiteSpace="pre-line">
+      Applications{"\n"}reopen in the Fall!
+    </Box>
+   }
+   offset={[0, 5]}
+   openDelay={250}
+   closeDelay={100}
+   placement="bottom"
+   bg="ctc.purple"
+   color="white"
+   borderRadius="md"
+   px={4}
+   py={2}
+   motionProps={{
+   initial: { opacity: 0, y: -8, scale: 0.9 },
+   animate: { opacity: 1, y: 0, scale: 1.0 },
+   exit: { opacity: 0, y: 6, scale: 1.0 },
+    transition: { duration: 0.2, ease: "easeOut" },
+   }}
+  >
+    <Box 
+     as="span" 
+     display="inline-block" 
+     cursor="none"
+     sx={{
+      "*": {
+      cursor: "s-resize !important",
+     },
+    }}
+    >
+      {linkContent}
+    </Box>
+  </Tooltip>
+ )
+}
+
 function DesktopNavbar({ pathname, navItems }: DesktopNavbarProps) {
  return (
   <Box
@@ -81,9 +123,8 @@ function DesktopNavbar({ pathname, navItems }: DesktopNavbarProps) {
     {navItems.map((item, index) => {
      const isActive = pathname === item.href;
      const isWIP = index >= navItems.length - 1; // Last two items
-     return (
+     const linkContent = (
       <ChakraLink
-       key={item.href}
        href={isWIP ? "#" : item.href}
        as={Link}
        color={isWIP ? "gray.400" : isActive ? "white" : "gray.800"}
@@ -129,6 +170,12 @@ function DesktopNavbar({ pathname, navItems }: DesktopNavbarProps) {
       >
        {item.label}
       </ChakraLink>
+     );
+
+     return isWIP && item.href === "/Recruitment" ? (
+      <RecruitmentTooltip linkContent={linkContent} href={item.href} key={item.href} />
+     ) : (
+      <Box key={item.href}>{linkContent}</Box>
      );
     })}
    </HStack>

--- a/src/utils/components/Navbars/DesktopNavbar.tsx
+++ b/src/utils/components/Navbars/DesktopNavbar.tsx
@@ -78,19 +78,17 @@ function DesktopNavbar({ pathname, navItems }: DesktopNavbarProps) {
      )}
     </ChakraLink>
 
-    {navItems.map((item, index) => {
+    {navItems.map((item) => {
      const isActive = pathname === item.href;
-    //  Set to 'navItems.length - 1' to set Recruitment as WIP
-     const isWIP = index >= navItems.length - 0;
      return (
       <ChakraLink
        key={item.href}
-       href={isWIP ? "#" : item.href}
+       href={item.href}
        as={Link}
-       color={isWIP ? "gray.400" : isActive ? "white" : "gray.800"}
+       color={isActive ? "white" : "gray.800"}
        fontWeight="500"
        fontSize="md"
-       bg={isActive && !isWIP ? "ctc.purple" : "transparent"}
+       bg={isActive ? "ctc.purple" : "transparent"}
        borderRadius="full"
        px={4}
        py={2}
@@ -116,17 +114,17 @@ function DesktopNavbar({ pathname, navItems }: DesktopNavbarProps) {
         opacity: 0,
        }}
        _hover={{
-        color: isWIP ? "gray.400" : isActive ? "white" : "ctc.purple",
-        bg: isActive && !isWIP ? "ctc.purple" : "transparent",
+        color: isActive ? "white" : "ctc.purple",
+        bg: isActive ? "ctc.purple" : "transparent",
         _before: {
-         transform: isWIP || isActive ? "scale(0)" : "scale(1)",
-         opacity: isWIP || isActive ? 0 : 1,
+         transform: isActive ? "scale(0)" : "scale(1)",
+         opacity: isActive ? 0 : 1,
         },
        }}
        transition="color 0.3s ease-out"
        textDecoration="none"
        whiteSpace="nowrap"
-       cursor={isWIP ? "not-allowed" : "pointer"}
+       cursor={"pointer"}
       >
        {item.label}
       </ChakraLink>

--- a/src/utils/components/Navbars/DesktopNavbar.tsx
+++ b/src/utils/components/Navbars/DesktopNavbar.tsx
@@ -1,52 +1,10 @@
-import { Box, HStack, Image, Link as ChakraLink, Tooltip } from "@chakra-ui/react";
+import { Box, HStack, Image, Link as ChakraLink } from "@chakra-ui/react";
 import Link from "next/link";
 
 type DesktopNavbarProps = {
  pathname: string;
  navItems: { label: string; href: string }[];
 };
-
-function RecruitmentTooltip({ linkContent, href }: { linkContent: React.ReactNode, href: string }) {
- return (
-  <Tooltip 
-   key={href} 
-   label={
-    <Box textAlign="center" whiteSpace="pre-line">
-      Applications{"\n"}reopen in the Fall!
-    </Box>
-   }
-   offset={[0, 5]}
-   openDelay={250}
-   closeDelay={100}
-   placement="bottom"
-   bg="ctc.purple"
-   color="white"
-   borderRadius="md"
-   px={4}
-   py={2}
-   motionProps={{
-   initial: { opacity: 0, y: -8, scale: 0.9 },
-   animate: { opacity: 1, y: 0, scale: 1.0 },
-   exit: { opacity: 0, y: 6, scale: 1.0 },
-    transition: { duration: 0.2, ease: "easeOut" },
-   }}
-  >
-    <Box 
-     as="span" 
-     display="inline-block" 
-     cursor="none"
-     sx={{
-      "*": {
-      cursor: "s-resize !important",
-     },
-    }}
-    >
-      {linkContent}
-    </Box>
-  </Tooltip>
- )
-}
-
 function DesktopNavbar({ pathname, navItems }: DesktopNavbarProps) {
  return (
   <Box
@@ -123,8 +81,9 @@ function DesktopNavbar({ pathname, navItems }: DesktopNavbarProps) {
     {navItems.map((item, index) => {
      const isActive = pathname === item.href;
      const isWIP = index >= navItems.length - 1; // Last two items
-     const linkContent = (
+     return (
       <ChakraLink
+       key={item.href}
        href={isWIP ? "#" : item.href}
        as={Link}
        color={isWIP ? "gray.400" : isActive ? "white" : "gray.800"}
@@ -170,12 +129,6 @@ function DesktopNavbar({ pathname, navItems }: DesktopNavbarProps) {
       >
        {item.label}
       </ChakraLink>
-     );
-
-     return isWIP && item.href === "/Recruitment" ? (
-      <RecruitmentTooltip linkContent={linkContent} href={item.href} key={item.href} />
-     ) : (
-      <Box key={item.href}>{linkContent}</Box>
      );
     })}
    </HStack>

--- a/src/utils/components/Navbars/DesktopNavbar.tsx
+++ b/src/utils/components/Navbars/DesktopNavbar.tsx
@@ -80,7 +80,8 @@ function DesktopNavbar({ pathname, navItems }: DesktopNavbarProps) {
 
     {navItems.map((item, index) => {
      const isActive = pathname === item.href;
-     const isWIP = index >= navItems.length - 1; // Last two items
+    //  Set to 'navItems.length - 1' to set Recruitment as WIP
+     const isWIP = index >= navItems.length - 0;
      return (
       <ChakraLink
        key={item.href}


### PR DESCRIPTION
Add a tooltip to the recruitment link in the desktop navbar when it is marked as isWIP. This adds context for users who may be trying to access the recruitment information, but only see a greyed out button.

<img width="294" height="167" alt="image" src="https://github.com/user-attachments/assets/5bea0abb-ca41-4354-9c37-48b932443cc4" />

Closes #2 